### PR TITLE
Test improvements

### DIFF
--- a/cachedfield/src/main/java/com/byoutline/cachedfield/CachedField.java
+++ b/cachedfield/src/main/java/com/byoutline/cachedfield/CachedField.java
@@ -45,4 +45,6 @@ public interface CachedField<RETURN_TYPE> {
      * @throws IllegalArgumentException if listener is null
      */
     boolean removeStateListener(FieldStateListener listener);
+
+    CachedFieldWithArg<RETURN_TYPE, Void> toCachedFieldWithArg();
 }

--- a/cachedfield/src/main/java/com/byoutline/cachedfield/CachedFieldImpl.java
+++ b/cachedfield/src/main/java/com/byoutline/cachedfield/CachedFieldImpl.java
@@ -98,4 +98,9 @@ public class CachedFieldImpl<RETURN_TYPE> implements CachedField<RETURN_TYPE> {
     public boolean removeStateListener(@Nonnull FieldStateListener listener) throws IllegalArgumentException {
         return delegate.removeStateListener(listener);
     }
+
+    @Override
+    public CachedFieldWithArg<RETURN_TYPE, Void> toCachedFieldWithArg() {
+        return delegate;
+    }
 }

--- a/cachedfield/src/main/java/com/byoutline/cachedfield/CachedFieldWithArg.java
+++ b/cachedfield/src/main/java/com/byoutline/cachedfield/CachedFieldWithArg.java
@@ -1,5 +1,7 @@
 package com.byoutline.cachedfield;
 
+import com.byoutline.cachedfield.cachedendpoint.StateAndValue;
+
 /**
  * Field of which getting value takes time (because it is downloaded from remote
  * source, or needs heavy calculations), so it is wrapped for caching.
@@ -26,6 +28,8 @@ public interface CachedFieldWithArg<RETURN_TYPE, ARG_TYPE> {
      * @param arg Argument needed to calculate value.
      */
     void refresh(ARG_TYPE arg);
+
+    StateAndValue<RETURN_TYPE, ARG_TYPE> getStateAndValue();
 
     /**
      * Forget cached value, so memory can be reclaimed.

--- a/cachedfield/src/main/java/com/byoutline/cachedfield/CachedFieldWithArgImpl.java
+++ b/cachedfield/src/main/java/com/byoutline/cachedfield/CachedFieldWithArgImpl.java
@@ -113,6 +113,11 @@ public class CachedFieldWithArgImpl<RETURN_TYPE, ARG_TYPE> implements CachedFiel
     }
 
     @Override
+    public StateAndValue<RETURN_TYPE, ARG_TYPE> getStateAndValue() {
+        return value.getStateAndValue();
+    }
+
+    @Override
     public void drop() {
         value.drop();
     }

--- a/cachedfield/src/main/java/com/byoutline/cachedfield/internal/ValueLoader.java
+++ b/cachedfield/src/main/java/com/byoutline/cachedfield/internal/ValueLoader.java
@@ -36,7 +36,7 @@ public class ValueLoader<RETURN_TYPE, ARG_TYPE> {
     /**
      * Loads value in separate thread.
      */
-    public void loadValue(final ARG_TYPE arg) {
+    public synchronized void loadValue(final ARG_TYPE arg) {
         if (fetchFuture != null) {
             // Cancel thread if it was not yet starter.
             fetchFuture.cancel(false);

--- a/cachedfield/src/main/java/com/byoutline/cachedfield/utils/SameSessionIdProvider.java
+++ b/cachedfield/src/main/java/com/byoutline/cachedfield/utils/SameSessionIdProvider.java
@@ -1,0 +1,15 @@
+package com.byoutline.cachedfield.utils;
+
+import javax.inject.Provider;
+
+/**
+ * Implementation of session ID that always returns same value.
+ * This can be used when application does not use concept of session
+ * for invalidating cache.
+ */
+public class SameSessionIdProvider implements Provider<String> {
+    @Override
+    public String get() {
+        return "";
+    }
+}

--- a/cachedfield/src/test/groovy/com/byoutline/cachedfield/CFMockFactory.groovy
+++ b/cachedfield/src/test/groovy/com/byoutline/cachedfield/CFMockFactory.groovy
@@ -226,7 +226,7 @@ static void waitUntilFieldWithArgLoads(CachedFieldWithArg field) {
         sleep 1
         sleepCount++
     }
-    sleep 2 // wait for success listener to get informed
+    sleep 8 // wait for success listener to get informed
 }
 
 static void loadValue(CachedFieldWithArg<String, Integer> field, Integer arg) {

--- a/cachedfield/src/test/groovy/com/byoutline/cachedfield/CFMockFactory.groovy
+++ b/cachedfield/src/test/groovy/com/byoutline/cachedfield/CFMockFactory.groovy
@@ -6,6 +6,7 @@ import com.byoutline.cachedfield.cachedendpoint.StateAndValue
 import com.byoutline.cachedfield.internal.DefaultExecutors
 import com.byoutline.cachedfield.internal.StubErrorListener
 import com.byoutline.cachedfield.internal.StubFieldStateListener
+import com.byoutline.cachedfield.utils.SameSessionIdProvider
 import com.google.common.util.concurrent.MoreExecutors
 
 import javax.inject.Provider
@@ -14,7 +15,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.FutureTask
 
 static Provider<String> getSameSessionIdProvider() {
-    return { return "sessionId" } as Provider<String>
+    return new SameSessionIdProvider()
 }
 
 static Provider<String> getMultiSessionIdProvider() {

--- a/cachedfield/src/test/groovy/com/byoutline/cachedfield/CFMockFactory.groovy
+++ b/cachedfield/src/test/groovy/com/byoutline/cachedfield/CFMockFactory.groovy
@@ -135,10 +135,10 @@ static CachedEndpointWithArgImpl<String, Integer> getCachedEndpointBlockingVal()
     return getCachedEndpointBlockingValueProv([arg: 'val'] as Map<Integer, String>)
 }
 
-static CachedEndpointWithArgImpl<String, Integer> getCachedEndpoint(Map<Integer, String> argToValueMap) {
+static CachedEndpointWithArgImpl<String, Integer> getDelayedCachedEndpoint(Map<Integer, String> argToValueMap, Long sleepTime) {
     return new CachedEndpointWithArgImpl(
             getSameSessionIdProvider(),
-            getStringIntGetter(argToValueMap),
+            getDelayedStringIntGetter(argToValueMap, sleepTime),
             getStubCallEndListener(),
             DefaultExecutors.createDefaultValueGetterExecutor(),
             DefaultExecutors.createDefaultStateListenerExecutor()
@@ -207,14 +207,14 @@ static CachedFieldWithArg getCachedFieldWithArg(Map<Integer, String> argToValueM
 
 static void waitUntilFieldLoads(CachedField field) {
     waitUntilFieldReachesState(field, FieldState.LOADED)
-    sleep 2 // wait for success listener to get informed
+    Thread.sleep(2) // wait for success listener to get informed
 }
 
 static void waitUntilFieldReachesState(CachedField field, FieldState state) {
     def sleepCount = 0
     def maxSleepCount = 5000
     while (field.getState() != state && sleepCount < maxSleepCount) {
-        sleep 1
+        Thread.sleep(1)
         sleepCount++
     }
 }
@@ -223,10 +223,10 @@ static void waitUntilFieldWithArgLoads(CachedFieldWithArg field) {
     def sleepCount = 0
     def maxSleepCount = 5000
     while (field.getState() != FieldState.LOADED && sleepCount < maxSleepCount) {
-        sleep 1
+        Thread.sleep(1)
         sleepCount++
     }
-    sleep 8 // wait for success listener to get informed
+    Thread.sleep(8) // wait for success listener to get informed
 }
 
 static void loadValue(CachedFieldWithArg<String, Integer> field, Integer arg) {

--- a/cachedfield/src/test/groovy/com/byoutline/cachedfield/CachedEndpointWithArgSpec.groovy
+++ b/cachedfield/src/test/groovy/com/byoutline/cachedfield/CachedEndpointWithArgSpec.groovy
@@ -8,8 +8,10 @@ import com.byoutline.cachedfield.internal.DefaultExecutors
 import com.google.common.util.concurrent.MoreExecutors
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Timeout
 
 import javax.inject.Provider
+import java.util.concurrent.TimeUnit
 
 /**
  *
@@ -48,22 +50,16 @@ class CachedEndpointWithArgSpec extends Specification {
         state == EndpointState.BEFORE_CALL
     }
 
+    @Timeout(value = 400, unit = TimeUnit.MILLISECONDS)
     def "call should return immediately"() {
         given:
-        CachedEndpointWithArg field = CFMockFactory.getCachedEndpoint(argToValueMap)
+        CachedEndpointWithArg field = CFMockFactory.getDelayedCachedEndpoint(argToValueMap, 4000)
 
         when:
-        boolean tookToLong = false
-        Thread.start {
-            sleep 15
-            tookToLong = true
-        }
         field.call(1)
 
-        then:
-        if (tookToLong) {
-            throw new AssertionError("Test took to long to execute")
-        }
+        then: 'postValue returns without waiting for value getter and method does not time out'
+        noExceptionThrown()
     }
 
     def "should inform endpoint state listener about current state"() {

--- a/cachedfield/src/test/groovy/com/byoutline/cachedfield/CachedFieldSpec.groovy
+++ b/cachedfield/src/test/groovy/com/byoutline/cachedfield/CachedFieldSpec.groovy
@@ -4,8 +4,10 @@ import com.byoutline.cachedfield.internal.DefaultExecutors
 import com.google.common.util.concurrent.MoreExecutors
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Timeout
 
 import javax.inject.Provider
+import java.util.concurrent.TimeUnit
 
 /**
  *
@@ -17,22 +19,16 @@ class CachedFieldSpec extends Specification {
     SuccessListener<String> stubSuccessListener = {} as SuccessListener<String>
 
 
+    @Timeout(value=400, unit = TimeUnit.MILLISECONDS)
     def "postValue should return immediately"() {
         given: 'instance that takes very long to load'
-        CachedField field = CFMockFactory.getDelayedCachedField(value, 1000, stubSuccessListener)
+        CachedField field = CFMockFactory.getDelayedCachedField(value, 4000, stubSuccessListener)
 
         when: 'postValue is called'
-        boolean tookToLong = false
-        Thread.start {
-            sleep 30
-            tookToLong = true
-        }
         field.postValue()
 
-        then: 'postValue does not block'
-        if (tookToLong) {
-            throw new AssertionError("Test took to long to execute")
-        }
+        then: 'postValue returns without waiting for value getter and method does not time out'
+        noExceptionThrown()
     }
 
 

--- a/cachedfield/src/test/groovy/com/byoutline/cachedfield/CachedFieldSpec.groovy
+++ b/cachedfield/src/test/groovy/com/byoutline/cachedfield/CachedFieldSpec.groovy
@@ -117,6 +117,7 @@ class CachedFieldSpec extends Specification {
         def stateList = { FieldState newState -> postedStates.add(newState) } as FieldStateListener
         CachedField field = CFMockFactory.getLoadedCachedField(value, stateList)
 
+
         when:
         field.refresh()
         sleep 1 // Wait for field to switch from LOADED to CURRENTLY_LOADING.

--- a/cachedfield/src/test/groovy/com/byoutline/cachedfield/CachedFieldWithArgExecutorsSpec.groovy
+++ b/cachedfield/src/test/groovy/com/byoutline/cachedfield/CachedFieldWithArgExecutorsSpec.groovy
@@ -4,10 +4,12 @@ import com.byoutline.cachedfield.internal.DefaultExecutors
 import com.google.common.util.concurrent.MoreExecutors
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.lang.Timeout
 
 import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
 
 /**
  *
@@ -53,6 +55,7 @@ class CachedFieldWithArgExecutorsSpec extends Specification {
         called
     }
 
+    @Timeout(value = 500, unit = TimeUnit.MILLISECONDS)
     def "should interrupt valueGetter thread"() {
         given:
         boolean valueLoadingInterrupted = false
@@ -77,13 +80,15 @@ class CachedFieldWithArgExecutorsSpec extends Specification {
         when:
         // Execute long running task asynchronously to be interrupted.
         field.postValue(10000)
+        field.postValue(1)
         // Give some (minimal) time to propagate Thread.interrupt, since we
         // are running this post synchronously.
-        field.postValue(8)
+        while (!valueLoadingInterrupted) {
+            sleep 1
+        }
 
         then:
         valueLoadingInterrupted
-        field.getState() == FieldState.LOADED
-//        thrown(InterruptedException)
+        // Or Fail by timeout
     }
 }

--- a/eventbuscachedfield/src/test/groovy/com/byoutline/eventbuscachedfield/EventBusCachedFieldSpec.groovy
+++ b/eventbuscachedfield/src/test/groovy/com/byoutline/eventbuscachedfield/EventBusCachedFieldSpec.groovy
@@ -4,6 +4,7 @@ import com.byoutline.cachedfield.MockCachedFieldLoader
 import com.byoutline.cachedfield.MockFactory
 import com.byoutline.cachedfield.testsuite.CachedFieldCommonSuiteSpec
 import com.byoutline.eventcallback.ResponseEvent
+import com.google.common.util.concurrent.MoreExecutors
 import de.greenrobot.event.EventBus
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -55,10 +56,11 @@ class EventBusCachedFieldSpec extends CachedFieldCommonSuiteSpec {
                 .withValueProvider(MockFactory.getFailingStringGetter(exception))
                 .withSuccessEvent(successEvent)
                 .withGenericErrorEvent(expEvent)
+                .withCustomValueGetterExecutor(MoreExecutors.newDirectExecutorService())
                 .build()
 
         when:
-        MockCachedFieldLoader.postAndWaitUntilFieldStopsLoading(field)
+        field.postValue()
 
         then:
         1 * bus.post(expEvent)

--- a/eventbuscachedfield/src/test/groovy/com/byoutline/eventbuscachedfield/EventBusCachedFieldSpec.groovy
+++ b/eventbuscachedfield/src/test/groovy/com/byoutline/eventbuscachedfield/EventBusCachedFieldSpec.groovy
@@ -1,31 +1,27 @@
 package com.byoutline.eventbuscachedfield
 
-import com.byoutline.cachedfield.CachedField
-import com.byoutline.cachedfield.FieldState
-import com.byoutline.cachedfield.FieldStateListener
 import com.byoutline.cachedfield.MockCachedFieldLoader
 import com.byoutline.cachedfield.MockFactory
+import com.byoutline.cachedfield.testsuite.CachedFieldCommonSuiteSpec
 import com.byoutline.eventcallback.ResponseEvent
 import de.greenrobot.event.EventBus
 import spock.lang.Shared
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import javax.inject.Provider
+import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
 
 /**
  *
  * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 27.06.14.
  */
-class EventBusCachedFieldSpec extends Specification {
-    @Shared
-    String value = "value"
+class EventBusCachedFieldSpec extends CachedFieldCommonSuiteSpec {
     @Shared
     Exception exception = new RuntimeException("Cached Field test exception")
     ResponseEvent<String> successEvent
     ResponseEvent<Exception> errorEvent
     EventBus bus
-
 
 
     def setup() {
@@ -36,35 +32,10 @@ class EventBusCachedFieldSpec extends Specification {
         EventBusCachedField.init(MockFactory.getSameSessionIdProvider(), bus)
     }
 
-    def "postValue should return immediately"() {
-        given:
-        EventBusCachedField field = EventBusCachedField.builder()
-                .withValueProvider(MockFactory.getDelayedStringGetter(value, 1000))
-                .withSuccessEvent(successEvent)
-                .build()
-
-        when:
-        boolean tookToLong = false
-        Thread.start {
-            sleep 40
-            tookToLong = true
-        }
-        field.postValue()
-
-        then:
-        if (tookToLong) {
-            throw new AssertionError("Test took to long to execute")
-        }
-    }
-
     @Unroll
     def "should post success times: #sC, error times: #eC for valueProvider: #valProv"() {
         when:
-        EventBusCachedField field = EventBusCachedField.builder()
-                .withValueProvider(valProv)
-                .withSuccessEvent(successEvent)
-                .withResponseErrorEvent(errorEvent)
-                .build()
+        EventBusCachedField field = getFieldWithDefaultExecutors(valProv)
         MockCachedFieldLoader.postAndWaitUntilFieldStopsLoading(field)
 
         then:
@@ -111,5 +82,16 @@ class EventBusCachedFieldSpec extends Specification {
         then:
         1 * customBus.post(_)
         0 * bus.post(_)
+    }
+
+    @Override
+    def getField(Provider<String> valueProvider, ExecutorService valueGetterExecutor, Executor stateListenerExecutor) {
+        return EventBusCachedField.builder()
+                .withValueProvider(valueProvider)
+                .withSuccessEvent(successEvent)
+                .withResponseErrorEvent(errorEvent)
+                .withCustomStateListenerExecutor(stateListenerExecutor)
+                .withCustomValueGetterExecutor(valueGetterExecutor)
+                .build()
     }
 }

--- a/eventbuscachedfield/src/test/groovy/com/byoutline/eventbuscachedfield/EventBusCachedFieldWithArgSpec.groovy
+++ b/eventbuscachedfield/src/test/groovy/com/byoutline/eventbuscachedfield/EventBusCachedFieldWithArgSpec.groovy
@@ -1,11 +1,9 @@
 package com.byoutline.eventbuscachedfield
 
-import com.byoutline.cachedfield.CachedFieldWithArg
-import com.byoutline.cachedfield.FieldState
-import com.byoutline.cachedfield.FieldStateListener
 import com.byoutline.cachedfield.MockCachedFieldLoader
 import com.byoutline.cachedfield.MockFactory
 import com.byoutline.ibuscachedfield.events.ResponseEventWithArg
+import com.google.common.util.concurrent.MoreExecutors
 import de.greenrobot.event.EventBus
 import spock.lang.Shared
 import spock.lang.Specification
@@ -39,9 +37,10 @@ class EventBusCachedFieldWithArgSpec extends Specification {
                 .withValueProvider(MockFactory.getStringGetter(argToValueMap))
                 .withSuccessEvent(successEvent)
                 .withResponseErrorEvent(errorEvent)
+                .withCustomValueGetterExecutor(MoreExecutors.newDirectExecutorService())
                 .build()
         when:
-        MockCachedFieldLoader.postAndWaitUntilFieldStopsLoading(field, arg)
+        field.postValue(arg)
 
         then:
 

--- a/gradle/byoutline/codeCoverage.gradle
+++ b/gradle/byoutline/codeCoverage.gradle
@@ -33,12 +33,14 @@ cobertura {
     rootProject.subprojects.each {
         coverageSourceDirs += it.sourceSets.main.java.srcDirs
     }
-    coverageMergeDatafiles = ['observablecachedfield',
-                              'ottocachedfield',
-                              'cachedfield',
-                              'ibuscachedfield',
-                              'ottoobservablecachedfield',
-                              'eventbuscachedfield']
+    coverageMergeDatafiles = [
+            'cachedfield',
+            'eventbuscachedfield',
+            'ibuscachedfield',
+            'idlingresource',
+            'observablecachedfield',
+            'ottocachedfield',
+            'ottoobservablecachedfield']
             .collect { new File("$it/build/cobertura/cobertura.ser") }
     coverageIgnoreTrivial = true
     coverageExcludes = ['.*AutoValue_.*']

--- a/gradle/byoutline/codeCoverage.gradle
+++ b/gradle/byoutline/codeCoverage.gradle
@@ -3,7 +3,6 @@ repositories {
 }
 
 subprojects {
-    apply plugin: 'java'
     apply plugin: 'net.saliman.cobertura'
 
     dependencies {
@@ -14,7 +13,7 @@ subprojects {
     }
     cobertura {
         coverageIgnoreTrivial = true
-        coverageFormats = [ 'xml', 'html' ]
+        coverageFormats = ['xml', 'html']
         coverageExcludes = ['.*AutoValue_.*']
     }
 }
@@ -22,8 +21,13 @@ subprojects {
 cobertura {
     coverageFormats = ['xml', 'html']
 
-    rootProject.subprojects.each {
-        coverageDirs << file("${it.sourceSets.main.output.classesDir}")
+    rootProject.subprojects.collectMany {
+        it.sourceSets.main.output.classesDirs.collect { "$it" }
+    }.each { path ->
+        if (path.contains('rxjava/build/classes/java')) {
+            path = path.replace('rxjava/build/classes/java', 'rxjava/build/classes/kotlin')
+        }
+        coverageDirs << file(path)
     }
     coverageSourceDirs = []
     rootProject.subprojects.each {

--- a/ibuscachedfield/build.gradle
+++ b/ibuscachedfield/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     api deps.cachedfield
     compileOnly 'com.squareup.retrofit2:retrofit:2.0.2'
     testImplementation project(':testhelpers')
+    testImplementation 'com.squareup.retrofit2:retrofit-mock:2.0.2'
 }
 
 apply from: '../maven-push.gradle'

--- a/ibuscachedfield/src/test/groovy/com/byoutline/ibuscachedfield/IBusCachedFieldSpec.groovy
+++ b/ibuscachedfield/src/test/groovy/com/byoutline/ibuscachedfield/IBusCachedFieldSpec.groovy
@@ -1,25 +1,23 @@
 package com.byoutline.ibuscachedfield
 
 import com.byoutline.cachedfield.CachedField
-import com.byoutline.cachedfield.FieldState
-import com.byoutline.cachedfield.FieldStateListener
 import com.byoutline.cachedfield.MockCachedFieldLoader
 import com.byoutline.cachedfield.MockFactory
+import com.byoutline.cachedfield.testsuite.CachedFieldCommonSuiteSpec
 import com.byoutline.eventcallback.IBus
 import com.byoutline.eventcallback.ResponseEvent
 import spock.lang.Shared
-import spock.lang.Specification
 import spock.lang.Unroll
 
 import javax.inject.Provider
+import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
 
 /**
  *
  * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 27.06.14.
  */
-class IBusCachedFieldSpec extends Specification {
-    @Shared
-    String value = "value"
+class IBusCachedFieldSpec extends CachedFieldCommonSuiteSpec {
     @Shared
     Exception exception = new RuntimeException("Cached Field test exception")
     ResponseEvent<String> successEvent
@@ -32,35 +30,10 @@ class IBusCachedFieldSpec extends Specification {
         errorEvent = Mock()
     }
 
-    def "postValue should return immediately"() {
-        given:
-        CachedField field = IBusMockFactory.fieldWithoutArgBuilder(bus)
-                .withValueProvider(MockFactory.getDelayedStringGetter(value, 1000))
-                .withSuccessEvent(successEvent)
-                .build()
-
-        when:
-        boolean tookToLong = false
-        Thread.start {
-            sleep 15
-            tookToLong = true
-        }
-        field.postValue()
-
-        then:
-        if (tookToLong) {
-            throw new AssertionError("Test took to long to execute")
-        }
-    }
-
     @Unroll
     def "should post success times: #sC, error times: #eC for valueProvider: #valProv"() {
         when:
-        CachedField field = IBusMockFactory.fieldWithoutArgBuilder(bus)
-                .withValueProvider(valProv)
-                .withSuccessEvent(successEvent)
-                .withResponseErrorEvent(errorEvent)
-                .build()
+        CachedField field = getFieldWithDefaultExecutors(valProv)
         MockCachedFieldLoader.postAndWaitUntilFieldStopsLoading(field)
 
         then:
@@ -107,5 +80,16 @@ class IBusCachedFieldSpec extends Specification {
         then:
         1 * customBus.post(_)
         0 * bus.post(_)
+    }
+
+    @Override
+    def getField(Provider<String> valueProvider, ExecutorService valueGetterExecutor, Executor stateListenerExecutor) {
+        return IBusMockFactory.fieldWithoutArgBuilder(bus)
+                .withValueProvider(valueProvider)
+                .withSuccessEvent(successEvent)
+                .withResponseErrorEvent(errorEvent)
+                .withCustomValueGetterExecutor(valueGetterExecutor)
+                .withCustomStateListenerExecutor(stateListenerExecutor)
+                .build()
     }
 }

--- a/ibuscachedfield/src/test/groovy/com/byoutline/ibuscachedfield/IBusCachedFieldSpec.groovy
+++ b/ibuscachedfield/src/test/groovy/com/byoutline/ibuscachedfield/IBusCachedFieldSpec.groovy
@@ -6,6 +6,7 @@ import com.byoutline.cachedfield.MockFactory
 import com.byoutline.cachedfield.testsuite.CachedFieldCommonSuiteSpec
 import com.byoutline.eventcallback.IBus
 import com.byoutline.eventcallback.ResponseEvent
+import com.google.common.util.concurrent.MoreExecutors
 import spock.lang.Shared
 import spock.lang.Unroll
 
@@ -53,10 +54,11 @@ class IBusCachedFieldSpec extends CachedFieldCommonSuiteSpec {
                 .withValueProvider(MockFactory.getFailingStringGetter(exception))
                 .withSuccessEvent(successEvent)
                 .withGenericErrorEvent(expEvent)
+                .withCustomValueGetterExecutor(MoreExecutors.newDirectExecutorService())
                 .build()
 
         when:
-        MockCachedFieldLoader.postAndWaitUntilFieldStopsLoading(field)
+        field.postValue()
 
         then:
         1 * bus.post(expEvent)

--- a/ibuscachedfield/src/test/groovy/com/byoutline/ibuscachedfield/util/RetrofitHelperSpec.groovy
+++ b/ibuscachedfield/src/test/groovy/com/byoutline/ibuscachedfield/util/RetrofitHelperSpec.groovy
@@ -1,0 +1,110 @@
+package com.byoutline.ibuscachedfield.util
+
+import com.byoutline.cachedfield.ProviderWithArg
+import com.byoutline.eventcallback.IBus
+import com.byoutline.eventcallback.ResponseEvent
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import retrofit2.Call
+import retrofit2.Response
+import retrofit2.mock.Calls
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.inject.Provider
+
+class RetrofitHelperSpec extends Specification {
+    @Shared
+    String value = 'value'
+    @Shared
+    def errorBody = ResponseBody.create(MediaType.parse('text'), 'error')
+    @Shared
+    Map<Integer, String> argToValueMap = [1: 'a', 2: 'b']
+
+    @Shared
+    Exception exception = new RuntimeException('Cached Field test exception')
+    ResponseEvent<String> successEvent
+    ResponseEvent<Exception> errorEvent
+    IBus bus
+
+    def setup() {
+        bus = Mock()
+        successEvent = Mock()
+        errorEvent = Mock()
+    }
+
+    def "apiValueProv should return call success as value NO ARGS"() {
+        given:
+        Provider<Call<String>> callProv = { Calls.response(value) }
+
+        when:
+        def result = RetrofitHelper.apiValueProv(callProv)
+
+        then:
+        result.get() == value
+    }
+
+    def "apiValueProv should return call success as value WITH ARGS"() {
+        given:
+        ProviderWithArg<Call<String>, Integer> callProv = { arg -> Calls.response(argToValueMap.get(arg)) }
+
+        when:
+        def result = RetrofitHelper.apiValueProv(callProv)
+
+        then:
+        result.get(1) == 'a'
+        result.get(2) == 'b'
+    }
+
+    def "apiValueProv should throw Exception on failure NO ARGS"() {
+        given:
+        Provider<Call<String>> callProv = { Calls.response(Response.error(404, errorBody)) }
+
+        when:
+        def result = RetrofitHelper.apiValueProv(callProv)
+        result.get()
+
+        then:
+        RetrofitHelper.ApiException ex = thrown()
+        ex.errorResponse.errorBody() == errorBody
+    }
+
+    def "apiValueProv should throw Exception on failure WITH ARGS"() {
+        given:
+        ProviderWithArg<Call<String>, Integer> callProv = { arg -> Calls.response(Response.error(404, errorBody)) }
+
+        when:
+        def result = RetrofitHelper.apiValueProv(callProv)
+        result.get()
+
+        then:
+        RetrofitHelper.ApiException ex = thrown()
+        ex.errorResponse.errorBody() == errorBody
+    }
+
+    def "apiValueProv should propagate exception NO ARGS"() {
+        given:
+        Provider<Call<String>> callProv = { Calls.failure(new IOException()) }
+
+        when:
+        def result = RetrofitHelper.apiValueProv(callProv)
+        result.get()
+
+        then:
+        RetrofitHelper.ApiException ex = thrown()
+        ex.cause instanceof IOException
+    }
+
+    def "apiValueProv should propagate exception WITH ARGS"() {
+        given:
+        ProviderWithArg<Call<String>, Integer> callProv = { arg -> Calls.failure(new IOException()) }
+
+        when:
+        def result = RetrofitHelper.apiValueProv(callProv)
+        result.get()
+
+        then:
+        RetrofitHelper.ApiException ex = thrown()
+        ex.cause instanceof IOException
+    }
+}

--- a/idlingresource/build.gradle
+++ b/idlingresource/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'propdeps'
 
-apply from: '../gradle/byoutline/forceJava6.gradle'
+apply from: '../gradle/byoutline/javaLib6.gradle'
 
 repositories {
     mavenCentral()
@@ -10,9 +10,13 @@ repositories {
 
 dependencies {
     compileOnly files('libs/espresso-idling-resource-2.2-release-no-dep.jar')
+
     compileOnly 'com.google.android:android:4.1.1.4'
 
     implementation deps.cachedfield
+
+    testImplementation files('libs/espresso-idling-resource-2.2-release-no-dep.jar')
+    testImplementation project(':testhelpers')
 }
 
 

--- a/idlingresource/src/test/groovy/com/byoutline/cachedfield/utils/CachedFieldIdlingResourceSpec.groovy
+++ b/idlingresource/src/test/groovy/com/byoutline/cachedfield/utils/CachedFieldIdlingResourceSpec.groovy
@@ -1,0 +1,127 @@
+package com.byoutline.cachedfield.utils
+
+import com.byoutline.cachedfield.*
+import com.byoutline.cachedfield.cachedendpoint.StateAndValue
+import spock.lang.Specification
+import spock.lang.Timeout
+import spock.lang.Unroll
+
+/**
+ *
+ * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com> on 27.06.14.
+ */
+class CachedFieldIdlingResourceSpec extends Specification {
+
+    @Timeout(1)
+    @Unroll
+    def "#name should return correct Idle status"() {
+        given:
+        def instance = CachedFieldIdlingResource.from(field)
+        def transitionToIdle = false
+        instance.registerIdleTransitionCallback { transitionToIdle = true }
+        def idleBeforeCall = instance.idleNow
+
+        when:
+        field.setState(FieldState.CURRENTLY_LOADING)
+        def idleDuringCall = instance.idleNow
+        field.setState(FieldState.LOADED)
+        def idleAfterCall = instance.idleNow
+
+        then:
+        idleBeforeCall
+        !idleDuringCall
+        idleAfterCall
+
+        where:
+        field               | name
+        new MockVanillaCF() | "vanilla"
+        new MockCFWithArg() | "with arg"
+    }
+}
+
+class MockCFWithArg implements CachedFieldWithArg<String, Integer> {
+
+    private FieldState state = FieldState.NOT_LOADED
+    FieldStateListener listener = null
+
+    @Override
+    FieldState getState() {
+        return state
+    }
+
+    void setState(FieldState state) {
+        this.state = state
+        listener?.fieldStateChanged(state)
+    }
+
+    @Override
+    void postValue(Integer arg) {
+    }
+
+    @Override
+    void refresh(Integer arg) {
+    }
+
+    @Override
+    StateAndValue<String, Integer> getStateAndValue() {
+        return StateAndValue.create(state, "", 1)
+    }
+
+    @Override
+    void drop() {
+    }
+
+    @Override
+    void addStateListener(FieldStateListener listener) {
+        this.listener = listener
+    }
+
+    @Override
+    boolean removeStateListener(FieldStateListener listener) {
+        if (this.listener == listener) {
+            this.listener = null
+            return true
+        }
+        return false
+    }
+}
+
+class MockVanillaCF implements CachedField<String> {
+    private delegate = new MockCFWithArg()
+
+    @Override
+    FieldState getState() {
+        return delegate.getState()
+    }
+
+    void setState(FieldState state) {
+        delegate.setState(state)
+    }
+
+    @Override
+    void postValue() {
+    }
+
+    @Override
+    void refresh() {
+    }
+
+    @Override
+    void drop() {
+    }
+
+    @Override
+    void addStateListener(FieldStateListener listener) {
+        delegate.addStateListener(listener)
+    }
+
+    @Override
+    boolean removeStateListener(FieldStateListener listener) {
+        delegate.removeStateListener(listener)
+    }
+
+    @Override
+    CachedFieldWithArgImpl<String, Void> toCachedFieldWithArg() {
+        return null
+    }
+}

--- a/observablecachedfield/src/main/java/com/byoutline/observablecachedfield/ObservableCachedField.java
+++ b/observablecachedfield/src/main/java/com/byoutline/observablecachedfield/ObservableCachedField.java
@@ -67,4 +67,9 @@ public class ObservableCachedField<RETURN_TYPE> implements CachedField<RETURN_TY
     public boolean removeStateListener(FieldStateListener listener) {
         return delegate.removeStateListener(listener);
     }
+
+    @Override
+    public ObservableCachedFieldWithArg<RETURN_TYPE, Void> toCachedFieldWithArg() {
+        return delegate;
+    }
 }

--- a/observablecachedfield/src/test/groovy/com/byoutline/observablecachedfield/ObservableCachedFieldSpec.groovy
+++ b/observablecachedfield/src/test/groovy/com/byoutline/observablecachedfield/ObservableCachedFieldSpec.groovy
@@ -1,0 +1,24 @@
+package com.byoutline.observablecachedfield
+
+import com.byoutline.cachedfield.ErrorListener
+import com.byoutline.cachedfield.MockFactory
+import com.byoutline.cachedfield.SuccessListener
+import com.byoutline.cachedfield.testsuite.CachedFieldCommonSuiteSpec
+
+import javax.inject.Provider
+import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
+
+class ObservableCachedFieldSpec extends CachedFieldCommonSuiteSpec {
+    @Override
+    def getField(Provider<String> valueProvider, ExecutorService valueGetterExecutor, Executor stateListenerExecutor) {
+        ObservableCachedField<String> field = new ObservableCachedField<String>(MockFactory.getSameSessionIdProvider(),
+                valueProvider,
+                {} as SuccessListener<String>,
+                {} as ErrorListener,
+                valueGetterExecutor,
+                stateListenerExecutor
+        )
+        return field
+    }
+}

--- a/ottocachedfield/src/test/groovy/com/byoutline/ottocachedfield/OttoCachedFieldSpec.groovy
+++ b/ottocachedfield/src/test/groovy/com/byoutline/ottocachedfield/OttoCachedFieldSpec.groovy
@@ -5,6 +5,7 @@ import com.byoutline.cachedfield.MockCachedFieldLoader
 import com.byoutline.cachedfield.MockFactory
 import com.byoutline.cachedfield.testsuite.CachedFieldCommonSuiteSpec
 import com.byoutline.eventcallback.ResponseEvent
+import com.google.common.util.concurrent.MoreExecutors
 import com.squareup.otto.Bus
 import spock.lang.Shared
 import spock.lang.Unroll
@@ -57,10 +58,11 @@ class OttoCachedFieldSpec extends CachedFieldCommonSuiteSpec {
                 .withValueProvider(MockFactory.getFailingStringGetter(exception))
                 .withSuccessEvent(successEvent)
                 .withGenericErrorEvent(expEvent)
+                .withCustomValueGetterExecutor(MoreExecutors.newDirectExecutorService())
                 .build()
 
         when:
-        MockCachedFieldLoader.postAndWaitUntilFieldStopsLoading(field)
+        field.postValue()
 
         then:
         1 * bus.post(expEvent)

--- a/ottoobservablecachedfield/src/test/groovy/com/byoutline/ottocachedfield/OttoObservableCachedFieldSpec.groovy
+++ b/ottoobservablecachedfield/src/test/groovy/com/byoutline/ottocachedfield/OttoObservableCachedFieldSpec.groovy
@@ -1,0 +1,25 @@
+package com.byoutline.ottocachedfield
+
+import com.byoutline.cachedfield.ErrorListener
+import com.byoutline.cachedfield.MockFactory
+import com.byoutline.cachedfield.SuccessListener
+import com.byoutline.cachedfield.testsuite.CachedFieldCommonSuiteSpec
+import com.byoutline.observablecachedfield.ObservableCachedField
+
+import javax.inject.Provider
+import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
+
+class OttoObservableCachedFieldSpec extends CachedFieldCommonSuiteSpec {
+    @Override
+    def getField(Provider<String> valueProvider, ExecutorService valueGetterExecutor, Executor stateListenerExecutor) {
+        ObservableCachedField<String> field = new ObservableCachedField<String>(MockFactory.getSameSessionIdProvider(),
+                valueProvider,
+                {} as SuccessListener<String>,
+                {} as ErrorListener,
+                valueGetterExecutor,
+                stateListenerExecutor
+        )
+        return field
+    }
+}

--- a/testhelpers/src/main/groovy/com/byoutline/cachedfield/MockCachedFieldLoader.groovy
+++ b/testhelpers/src/main/groovy/com/byoutline/cachedfield/MockCachedFieldLoader.groovy
@@ -18,6 +18,14 @@ static <ARG_TYPE> void postAndWaitUntilFieldStopsLoading(CachedFieldWithArg<?, A
 }
 
 static void postAndWaitUntilFieldStopsLoading(CachedField field) {
+    doAndWaitForCachedFieldAction(field, true)
+}
+
+static void refreshAndWaitUntilFieldStopsLoading(CachedField field) {
+    doAndWaitForCachedFieldAction(field, false)
+}
+
+private static void doAndWaitForCachedFieldAction(CachedField field, Boolean post) {
     boolean duringValueLoad = true
     def listener = { FieldState newState ->
         if (newState == FieldState.NOT_LOADED || newState == FieldState.LOADED) {
@@ -26,7 +34,11 @@ static void postAndWaitUntilFieldStopsLoading(CachedField field) {
     } as FieldStateListener
 
     field.addStateListener(listener)
-    field.postValue()
+    if (post) {
+        field.postValue()
+    } else {
+        field.refresh()
+    }
     while (duringValueLoad) {
         sleep 1
     }

--- a/testhelpers/src/main/groovy/com/byoutline/cachedfield/MockFactory.groovy
+++ b/testhelpers/src/main/groovy/com/byoutline/cachedfield/MockFactory.groovy
@@ -6,6 +6,7 @@ import com.byoutline.cachedfield.cachedendpoint.StateAndValue
 import com.byoutline.cachedfield.internal.DefaultExecutors
 import com.byoutline.cachedfield.internal.StubErrorListener
 import com.byoutline.cachedfield.internal.StubFieldStateListener
+import com.byoutline.cachedfield.utils.SameSessionIdProvider
 import com.google.common.util.concurrent.MoreExecutors
 
 import javax.inject.Provider
@@ -14,7 +15,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.FutureTask
 
 static Provider<String> getSameSessionIdProvider() {
-    return { return "sessionId" } as Provider<String>
+    return new SameSessionIdProvider()
 }
 
 static Provider<String> getMultiSessionIdProvider() {

--- a/testhelpers/src/main/groovy/com/byoutline/cachedfield/testsuite/CachedFieldCommonSuiteSpec.groovy
+++ b/testhelpers/src/main/groovy/com/byoutline/cachedfield/testsuite/CachedFieldCommonSuiteSpec.groovy
@@ -1,0 +1,136 @@
+package com.byoutline.cachedfield.testsuite
+
+import com.byoutline.cachedfield.CachedField
+import com.byoutline.cachedfield.FieldState
+import com.byoutline.cachedfield.FieldStateListener
+import com.byoutline.cachedfield.MockFactory
+import com.byoutline.cachedfield.cachedendpoint.CallResult
+import com.byoutline.cachedfield.cachedendpoint.EndpointState
+import com.byoutline.cachedfield.internal.DefaultExecutors
+import com.google.common.util.concurrent.MoreExecutors
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Timeout
+
+import javax.inject.Provider
+import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
+
+import static com.byoutline.cachedfield.MockCachedFieldLoader.postAndWaitUntilFieldStopsLoading
+import static com.byoutline.cachedfield.MockCachedFieldLoader.refreshAndWaitUntilFieldStopsLoading
+
+abstract class CachedFieldCommonSuiteSpec extends Specification {
+    @Shared
+    def value = "value"
+
+    abstract
+    def getField(Provider<String> valueProvider, ExecutorService valueGetterExecutor, Executor stateListenerExecutor)
+
+    def getFieldWithDefaultExecutors(Provider<String> valueProvider) {
+        return getField(valueProvider, DefaultExecutors.createDefaultValueGetterExecutor(),
+                DefaultExecutors.createDefaultStateListenerExecutor())
+    }
+
+    @Timeout(1)
+    def "should allow self removing state listeners"() {
+        given:
+        CachedField field = getFieldWithDefaultExecutors(MockFactory.getStringGetter(value))
+        def stateListeners = [new SelfRemovingFieldStateListener(field),
+                              new SelfRemovingFieldStateListener(field),
+                              new SelfRemovingFieldStateListener(field)]
+        stateListeners.each { field.addStateListener(it) }
+        when:
+        postAndWaitUntilFieldStopsLoading(field)
+        then:
+        stateListeners.findAll { it.called }.size() == 3
+    }
+
+    @Timeout(1)
+    def "should inform field state listener about changes on refresh"() {
+        given:
+        def postedStates = []
+        def stateList = { FieldState newState -> postedStates.add(newState) } as FieldStateListener
+        def field = getFieldWithDefaultExecutors(MockFactory.getStringGetter(value))
+        field.addStateListener(stateList)
+
+        when:
+        refreshAndWaitUntilFieldStopsLoading(field)
+
+        then:
+        postedStates == [FieldState.CURRENTLY_LOADING, FieldState.LOADED]
+    }
+
+    @Timeout(1)
+    def "should inform field state listener about changes on postValue"() {
+        given:
+        def postedStates = []
+        def stateList = { FieldState newState -> postedStates.add(newState) } as FieldStateListener
+        def field = getFieldWithDefaultExecutors(MockFactory.getStringGetter(value))
+        field.addStateListener(stateList)
+
+        when:
+        postAndWaitUntilFieldStopsLoading(field)
+
+        then:
+        postedStates == [FieldState.CURRENTLY_LOADING, FieldState.LOADED]
+    }
+
+    @Timeout(1)
+    def "postValue should return immediately"() {
+        given:
+        def field = getFieldWithDefaultExecutors(MockFactory.getDelayedStringGetter(value, 2000))
+
+        when:
+        boolean tookToLong = false
+        Thread.start {
+            sleep 15
+            tookToLong = true
+        }
+        field.postValue()
+
+        then:
+        if (tookToLong) {
+            throw new AssertionError("Test took to long to execute")
+        }
+    }
+
+    def "should inform field state listener about changes on drop"() {
+        given:
+        def postedStates = []
+        def stateList = { FieldState newState -> postedStates.add(newState) } as FieldStateListener
+        CachedField field = getField(MockFactory.getStringGetter(value),
+                MoreExecutors.newDirectExecutorService(),
+                MoreExecutors.directExecutor())
+        field.postValue()
+        field.addStateListener(stateList)
+
+        when:
+        field.drop()
+
+        then:
+        def stateAndValue = field.toCachedFieldWithArg().getStateAndValue()
+        postedStates == [FieldState.NOT_LOADED]
+        stateAndValue.state == EndpointState.BEFORE_CALL
+        stateAndValue.value == CallResult.create(null, null)
+        stateAndValue.arg == null
+    }
+
+    def "should remove state listener"() {
+        given:
+        def listenerCalls = 0
+        def stateList = { listenerCalls++ } as FieldStateListener
+        CachedField field = getField(MockFactory.getStringGetter(value),
+                MoreExecutors.newDirectExecutorService(),
+                MoreExecutors.directExecutor())
+        field.addStateListener(stateList)
+        field.postValue()
+
+        when:
+        field.removeStateListener(stateList)
+        field.postValue()
+        field.drop()
+
+        then:
+        listenerCalls == 2//only first postValue call state listener two times
+    }
+}

--- a/testhelpers/src/main/groovy/com/byoutline/cachedfield/testsuite/CachedFieldCommonSuiteSpec.groovy
+++ b/testhelpers/src/main/groovy/com/byoutline/cachedfield/testsuite/CachedFieldCommonSuiteSpec.groovy
@@ -15,6 +15,7 @@ import spock.lang.Timeout
 import javax.inject.Provider
 import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
 
 import static com.byoutline.cachedfield.MockCachedFieldLoader.postAndWaitUntilFieldStopsLoading
 import static com.byoutline.cachedfield.MockCachedFieldLoader.refreshAndWaitUntilFieldStopsLoading
@@ -75,23 +76,16 @@ abstract class CachedFieldCommonSuiteSpec extends Specification {
         postedStates == [FieldState.CURRENTLY_LOADING, FieldState.LOADED]
     }
 
-    @Timeout(1)
+    @Timeout(value=500, unit = TimeUnit.MILLISECONDS)
     def "postValue should return immediately"() {
         given:
-        def field = getFieldWithDefaultExecutors(MockFactory.getDelayedStringGetter(value, 2000))
+        def field = getFieldWithDefaultExecutors(MockFactory.getDelayedStringGetter(value, 4000))
 
         when:
-        boolean tookToLong = false
-        Thread.start {
-            sleep 15
-            tookToLong = true
-        }
         field.postValue()
 
-        then:
-        if (tookToLong) {
-            throw new AssertionError("Test took to long to execute")
-        }
+        then: 'postValue returns without waiting for value getter and method does not time out'
+        noExceptionThrown()
     }
 
     def "should inform field state listener about changes on drop"() {

--- a/testhelpers/src/main/groovy/com/byoutline/cachedfield/testsuite/SelfRemovingFieldStateListener.groovy
+++ b/testhelpers/src/main/groovy/com/byoutline/cachedfield/testsuite/SelfRemovingFieldStateListener.groovy
@@ -1,0 +1,24 @@
+package com.byoutline.cachedfield.testsuite
+
+import com.byoutline.cachedfield.CachedField
+import com.byoutline.cachedfield.FieldState
+import com.byoutline.cachedfield.FieldStateListener
+
+/**
+ * @author Sebastian Kacprzak <sebastian.kacprzak at byoutline.com>
+ */
+class SelfRemovingFieldStateListener implements FieldStateListener {
+    final CachedField field
+    boolean called = false
+
+    SelfRemovingFieldStateListener(CachedField field) {
+        this.field = field
+    }
+
+    @Override
+    void fieldStateChanged(FieldState newState) {
+        System.out.println("Called")
+        called = true
+        field.removeStateListener(this)
+    }
+}


### PR DESCRIPTION
API
===
* `toCachedFieldWithArg` will convert(unpack) `CachedField` to `CachedFieldWithArg`
* `getStateAndValue` that returns complete current state
* `SameSessionIdProvider` - default implementation for `sessionId` Provider. (This was previously used by test, but is also usefull for projects that did not use `sessionId`)

Tests
=====
* Common suite of tests for various CachedField modules
* RetrofitHelper Test
* CachedFieldIdlingResource test
* CI stability improvements